### PR TITLE
Java 8 to Java 17 so that build will work with new bndlib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             uses: actions/setup-java@v2
             with: 
                 distribution: 'temurin'
-                java-version: 8
+                java-version: 17
         -   name: Build
             shell: bash
             run: ./gradlew build


### PR DESCRIPTION
This is fix to actions/gradle builder to use java 17 rather than java 8.  This is in support of fix for issue #17 